### PR TITLE
Build fixes and helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Outbound WebHook for Jenkins build events
 
 
-## Configration
+## Configuration
 
 Configure your Jenkins URL in `Jenkins > Configuration` section:
 
@@ -30,31 +30,42 @@ Add `Outbound Webhook notification` to `Post-build Actions`:
 
 ## Compile
 
+```bash
 ./gradlew build
+
+# or within a docker image:
+./gradlew-docker build
+```
 
 
 ## Test
 
+```bash
 ./gradlew test
+
+# or within a docker image:
+./gradlew-docker test
+```
 
 
 ## Run server
 
+```bash
 ./gradlew server
+
+# or within a docker image, port 8080 is forwarded to the docker host:
+./gradlew-docker server
+```
 
 Visit http://localhost:8080
 
-The frist time you visit it, you are required to go through the setup process.
+The first time you visit it, you are required to go through the setup process.
 Please **don't install** any third-party plugins. This plugin we currently working on will be installed by default.
 
 
 ## Admin user
 
-I use the following credential for testing:
-
-```
-admin/admin
-```
+I use the following credential for testing: `admin/admin`
 
 Of course you don't have to copy my example.
 
@@ -72,4 +83,11 @@ password=password
 
 Note: The credentials are from https://accounts.jenkins.io/.
 
-Run `./gradlew clean publish`.
+Run:
+
+```bash
+./gradlew clean publish
+
+# or within a docker image:
+./gradlew-docker clean publish
+```

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,10 @@ jenkinsPlugin {
 }
 
 repositories {
+    maven { url 'http://bits.netbeans.org/maven2' }
+    maven { url 'http://repo.jenkins-ci.org/releases/' }
     jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/gradlew-docker
+++ b/gradlew-docker
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+sudo docker run --rm -ti \
+  -p 8080:8080 \
+  -e JAVA_HOME=/docker-java-home \
+  -v $(pwd):/home/gradle/project \
+  -v $(pwd)/.gradle:/home/gradle/.gradle \
+  -w /home/gradle/project \
+  gradle:jdk8 ./gradlew $@
+
+exit $?


### PR DESCRIPTION
This PR mainly fixes the following build error:

> Could not find bootstrap-core-assets.jar (org.jenkins-ci.ui:bootstrap:1.3.2)

- Updated repositories to fix build errors
- added docker helper command for gradle image
- updated readme

Full disclosure, I'm not a java dev so the repositories might not be 100% correct however the builds are completing now. I'm just getting prepared to improve this plugin for pipeline support.