### PR TITLE
Close the response body

### DIFF
--- a/src/main/java/org/jenkins/plugins/JobListener.java
+++ b/src/main/java/org/jenkins/plugins/JobListener.java
@@ -78,11 +78,16 @@ public class JobListener extends RunListener<AbstractBuild> {
         String jsonString = JSON.toJSONString(object);
         RequestBody body = RequestBody.create(JSON_MEDIA_TYPE, jsonString);
         Request request = new Request.Builder().url(url).post(body).build();
+        Response response = null;
         try {
-            Response response = client.newCall(request).execute();
+            response = client.newCall(request).execute();
             log.debug("Invocation of webhook {} successful", url);
         } catch (Exception e) {
-        	log.info("Invocation of webhook {} failed", url, e);
+            log.info("Invocation of webhook {} failed", url, e);
+        } finally {
+            if (response != null) {
+                response.close();
+            }
         }
     }
 }


### PR DESCRIPTION
This addresses the following warning in the Jenkins log:

```
WARNING: A connection to http://hostname:port/ was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);
```

The javadoc about closing the response body can be found here:

- http://static.javadoc.io/com.squareup.okhttp3/okhttp/3.8.1/okhttp3/Call.html#execute--
- http://static.javadoc.io/com.squareup.okhttp3/okhttp/3.8.1/okhttp3/ResponseBody.html